### PR TITLE
Logic to update device tags per applicable scope

### DIFF
--- a/Get-Scope.ps1
+++ b/Get-Scope.ps1
@@ -19,11 +19,38 @@ $dict = @{}
 
 foreach ($devicePath in $relativeDeviceFolders) {
     $key = (Split-Path -Leaf $devicePath).Split('.')[0]
-    $value = Get-Scope-Array -currentRelativePath $devicePath
+
+    $value = New-Object PSObject -Property @{ ScopeArray=@(); Hub="" }
+    $value.ScopeArray = Get-Scope-Array -currentRelativePath $devicePath
+    $devicePath -match "^*\w+.hub*" > $null
+    $value.Hub = $matches[0].Split('.')[0]
 
     $dict.Add($key, $value)
 }
 
 $dict
+
+#subscription id will come from github secrets
+az account set --subscription ""
+az account show
+
+#replace with cxn str, todo implement Get-HubCxnString $dict[$device].Hub using GitHub secrets
+$westhub_cxnstr = "" 
+$easthub_cxnstr = ""
+
+foreach ($device in $dict.Keys) {        
+    if( $dict[$device].Hub -eq 'east' ) {
+        $hub_cxnstr = $easthub_cxnstr
+    } else {
+        $hub_cxnstr = $westhub_cxnstr
+    }
+    
+    $formattedScopeArray = $($dict[$device].ScopeArray | ConvertTo-Json) -replace "`n"," " -replace "`r"," " -replace """","'"
+    $tagsJson = "{ 'env': $formattedScopeArray}"
+    
+    az iot hub device-twin update --device-id $device --login $hub_cxnstr --tags $tagsJson
+}
+
+
 
 


### PR DESCRIPTION
Sample twin outputs:

{
  "deviceId": "device8",
  "etag": "AAAAAAAAAAI=",
  "deviceEtag": "NzcyMzQ3NTEx",
  "status": "enabled",
  "statusUpdateTime": "0001-01-01T00:00:00Z",
  "connectionState": "Disconnected",
  "lastActivityTime": "0001-01-01T00:00:00Z",
  "cloudToDeviceMessageCount": 0,
  "authenticationType": "sas",
  "x509Thumbprint": {
    "primaryThumbprint": null,
    "secondaryThumbprint": null
  },
  "modelId": "",
  "version": 3,
  "tags": {
    "env": [
      "global",
      "west",
      "europe"
    ]
  },
  "properties": {
    "desired": {
      "$metadata": {
        "$lastUpdated": "2021-02-22T22:11:20.6922065Z"
      },
      "$version": 1
    },
    "reported": {
      "$metadata": {
        "$lastUpdated": "2021-02-22T22:11:20.6922065Z"
      },
      "$version": 1
    }
  },
  "capabilities": {
    "iotEdge": true
  },
  "deviceScope": "ms-azure-iot-edge://device8-637496286806922065"
}

{
  "deviceId": "device3",
  "etag": "AAAAAAAAAAI=",
  "deviceEtag": "NjA2MzI0NDYw",
  "status": "enabled",
  "statusUpdateTime": "0001-01-01T00:00:00Z",
  "connectionState": "Disconnected",
  "lastActivityTime": "0001-01-01T00:00:00Z",
  "cloudToDeviceMessageCount": 0,
  "authenticationType": "sas",
  "x509Thumbprint": {
    "primaryThumbprint": null,
    "secondaryThumbprint": null
  },
  "modelId": "",
  "version": 3,
  "tags": {
    "env": [
      "global",
      "east",
      "africa"
    ]
  },
  "properties": {
    "desired": {
      "$metadata": {
        "$lastUpdated": "2021-02-22T22:13:31.5855889Z"
      },
      "$version": 1
    },
    "reported": {
      "$metadata": {
        "$lastUpdated": "2021-02-22T22:13:31.5855889Z"
      },
      "$version": 1
    }
  },
  "capabilities": {
    "iotEdge": true
  },
  "deviceScope": "ms-azure-iot-edge://device3-637496288115855889"
}